### PR TITLE
add support for events in Service and Ciliumegressgatewaypolicy

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,13 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - cilium.io
   resources:
   - ciliumegressgatewaypolicies

--- a/main.go
+++ b/main.go
@@ -93,17 +93,19 @@ func main() {
 	}
 
 	if err = (&controllers.ServiceReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("Service"),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Log:      ctrl.Log.WithName("controllers").WithName("Service"),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("kube-vip-cilium-watcher"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Unable to create controller Service")
 		os.Exit(1)
 	}
 	if err = (&controllers.CiliumEgressGatewayPolicyReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("CiliumEgressGatewayPolicy"),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Log:      ctrl.Log.WithName("controllers").WithName("CiliumEgressGatewayPolicy"),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("kube-vip-cilium-watcher"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller CiliumEgressGatewayPolicy")
 		os.Exit(1)

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -1,7 +1,10 @@
 package kubevipciliumwatcher
 
 const (
-	ServiceMustBeWatched = "kube-vip.io/cilium-egress-watcher"
-	KubeVipAnnotation    = "kube-vip.io/vipHost"
-	EgressVipAnnotation  = "kube-vip.io/host"
+	ServiceMustBeWatched       = "kube-vip.io/cilium-egress-watcher"
+	KubeVipAnnotation          = "kube-vip.io/vipHost"
+	EgressVipAnnotation        = "kube-vip.io/host"
+	EventServiceUpdateReason   = "EgressAssigned"
+	EventServiceNotFoundReason = "EgressNotFound"
+	EventEgressUpdateReason    = "Updated"
 )


### PR DESCRIPTION
When Services and CiliumEgressGatewayPolicy are updated, an event is generated:

![image](https://github.com/angeloxx/kube-vip-cilium-watcher/assets/550769/020a13dd-bdd9-4ea2-b3dd-8f3c4a763693)
